### PR TITLE
Fixed scale issue in conversion function

### DIFF
--- a/measure/build.gradle.kts
+++ b/measure/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
 
-    // Apply dokka plugin to allow extraction of ducumentation from KDoc comments
-    id("org.jetbrains.dokka") version "1.4.20"
+    // Apply dokka plugin to allow extraction of documentation from KDoc comments
+    id("org.jetbrains.dokka") version "1.4.32"
 
     // Make sure we can publish to maven
     `maven-publish`

--- a/measure/src/main/kotlin/com/alliander/open/measure/Measure.kt
+++ b/measure/src/main/kotlin/com/alliander/open/measure/Measure.kt
@@ -43,7 +43,7 @@ data class Measure<U : Units>(val amount: BigDecimal, val units: U) : Comparable
     infix fun <A : U> `in`(other: A): BigDecimal =
         if (units == other)
             amount
-        else (amount * units.ratio).divide(other.ratio, amount.scale() + units.ratio.precision(), RoundingMode.UP)
+        else (amount * units.ratio).divide(other.ratio, amount.scale() + other.ratio.precision(), RoundingMode.UP)
 
     operator fun plus(other: Measure<U>): Measure<U> = baseUnits(
         units,

--- a/measure/src/test/kotlin/com/alliander/open/measure/MeasureTest.kt
+++ b/measure/src/test/kotlin/com/alliander/open/measure/MeasureTest.kt
@@ -218,4 +218,10 @@ class MeasureTest : StringSpec({
 
         result shouldBe expectedResult
     }
+
+    "Unit conversion uses the correct scale" {
+        val energyInJoule = 13500000 * joule
+        val valueInKwh = energyInJoule `in` kiloWattHour
+        valueInKwh.stripTrailingZeros() shouldBe BigDecimal.valueOf(3.75)
+    }
 })


### PR DESCRIPTION
fixed a bug where unit conversion used the wrong scale, leading to rounding issues:

val energyInJoule = 13500000 * joule
val valueInKwh = energyInJoule `in` kiloWattHour

would result in 3.8 kwh instead of the expected 3.75 kwh