### PR TITLE
fix and tests for lost precision in unit conversion

### DIFF
--- a/measure/src/main/kotlin/com/alliander/open/measure/Measure.kt
+++ b/measure/src/main/kotlin/com/alliander/open/measure/Measure.kt
@@ -47,7 +47,7 @@ data class Measure<U : Units>(val amount: BigDecimal, val units: U) : Comparable
     infix fun <A : U> `in`(other: A): BigDecimal =
         if (units == other)
             amount
-        else (amount * units.ratio).divide(other.ratio, amount.scale() + units.ratio.precision(), RoundingMode.UP)
+        else (amount * units.ratio).divide(other.ratio, amount.scale() + other.ratio.precision(), RoundingMode.UP)
 
     operator fun plus(other: Measure<U>): Measure<U> = baseUnits(
         units,

--- a/measure/src/test/kotlin/com/alliander/open/measure/MeasureTest.kt
+++ b/measure/src/test/kotlin/com/alliander/open/measure/MeasureTest.kt
@@ -224,6 +224,10 @@ class MeasureTest : StringSpec({
         val valueInKwh = energyInJoule `in` kiloWattHour
         valueInKwh.stripTrailingZeros() shouldBe BigDecimal.valueOf(3.75)
 
+        val energyInJoule2 = 3.75 * kiloWattHour
+        val valueInKwh2 = energyInJoule2 `in` joule
+        valueInKwh2.stripTrailingZeros() shouldBe BigDecimal.valueOf(1.35E+7)
+
         val powerInW = 1.99E7 * watt
         val valueInMw = powerInW `as` megaWatt
         valueInMw.amount.stripTrailingZeros() shouldBe BigDecimal.valueOf(19.9)

--- a/measure/src/test/kotlin/com/alliander/open/measure/MeasureTest.kt
+++ b/measure/src/test/kotlin/com/alliander/open/measure/MeasureTest.kt
@@ -218,4 +218,14 @@ class MeasureTest : StringSpec({
 
         result shouldBe expectedResult
     }
+
+    "Unit conversion uses the correct scale" {
+        val energyInJoule = 13500000 * joule
+        val valueInKwh = energyInJoule `in` kiloWattHour
+        valueInKwh.stripTrailingZeros() shouldBe BigDecimal.valueOf(3.75)
+
+        val powerInW = 1.99E7 * watt
+        val valueInMw = powerInW `as` megaWatt
+        valueInMw.amount.stripTrailingZeros() shouldBe BigDecimal.valueOf(19.9)
+    }
 })


### PR DESCRIPTION
There's a small issue that causes a loss of precision when converting between units.

- 13500000 joule becomes 3.8Kwh instead of 3.75Kwh
- 1.99E7 watt becomes 10Mw instead of 19.9Mw

This fixes the issue