### PR TITLE
MRT-2464: add volt-ampere reactive

### DIFF
--- a/measure/src/main/kotlin/com/alliander/open/measure/SpecificUnits.kt
+++ b/measure/src/main/kotlin/com/alliander/open/measure/SpecificUnits.kt
@@ -26,9 +26,9 @@ class Power(suffix: String, ratio: BigDecimal = BigDecimal.ONE) : Units(suffix, 
 
 class ReactivePower(suffix: String, ratio: BigDecimal = BigDecimal.ONE) : Units(suffix, ratio) {
     companion object {
-        val voltAmpereReactive = ReactivePower("VAr")
+        val voltAmpereReactive = ReactivePower("VAr", 1.toBigDecimal())
         val kiloVoltAmpereReactive = ReactivePower("kVAr", 1_000.toBigDecimal())
-        val megaVoltAmpereReactive = ReactivePower("MVAr", 1_000_000.0.toBigDecimal())
+        val megaVoltAmpereReactive = ReactivePower("MVAr", 1_000_000.toBigDecimal())
     }
 }
 

--- a/measure/src/main/kotlin/com/alliander/open/measure/SpecificUnits.kt
+++ b/measure/src/main/kotlin/com/alliander/open/measure/SpecificUnits.kt
@@ -26,9 +26,9 @@ class Power(suffix: String, ratio: BigDecimal = BigDecimal.ONE) : Units(suffix, 
 
 class ReactivePower(suffix: String, ratio: BigDecimal = BigDecimal.ONE) : Units(suffix, ratio) {
     companion object {
-        val voltAmpereReactive = ReactivePower("var")
-        val kiloVoltAmpereReactive = ReactivePower("kvar", 1_000.toBigDecimal())
-        val megaVoltAmpereReactive = ReactivePower("Mvar", 1_000_000.0.toBigDecimal())
+        val voltAmpereReactive = ReactivePower("VAr")
+        val kiloVoltAmpereReactive = ReactivePower("kVAr", 1_000.toBigDecimal())
+        val megaVoltAmpereReactive = ReactivePower("MVAr", 1_000_000.0.toBigDecimal())
     }
 }
 

--- a/measure/src/main/kotlin/com/alliander/open/measure/SpecificUnits.kt
+++ b/measure/src/main/kotlin/com/alliander/open/measure/SpecificUnits.kt
@@ -26,9 +26,9 @@ class Power(suffix: String, ratio: BigDecimal = BigDecimal.ONE) : Units(suffix, 
 
 class ReactivePower(suffix: String, ratio: BigDecimal = BigDecimal.ONE) : Units(suffix, ratio) {
     companion object {
-        val voltAmpereReactive = Power("var")
-        val kiloVoltAmpereReactive = Power("kvar", 1_000.toBigDecimal())
-        val megaVoltAmpereReactive = Power("Mvar", 1_000_000.0.toBigDecimal())
+        val voltAmpereReactive = ReactivePower("var")
+        val kiloVoltAmpereReactive = ReactivePower("kvar", 1_000.toBigDecimal())
+        val megaVoltAmpereReactive = ReactivePower("Mvar", 1_000_000.0.toBigDecimal())
     }
 }
 

--- a/measure/src/main/kotlin/com/alliander/open/measure/SpecificUnits.kt
+++ b/measure/src/main/kotlin/com/alliander/open/measure/SpecificUnits.kt
@@ -21,6 +21,9 @@ class Power(suffix: String, ratio: BigDecimal = BigDecimal.ONE) : Units(suffix, 
         val watt = Power("W")
         val kiloWatt = Power("kW", 1_000.toBigDecimal())
         val megaWatt = Power("MW", 1_000_000.0.toBigDecimal())
+        val voltAmpereReactive = Power("var")
+        val kiloVoltAmpereReactive = Power("kvar", 1_000.toBigDecimal())
+        val megaVoltAmpereReactive = Power("Mvar", 1_000_000.0.toBigDecimal())
     }
 }
 

--- a/measure/src/main/kotlin/com/alliander/open/measure/SpecificUnits.kt
+++ b/measure/src/main/kotlin/com/alliander/open/measure/SpecificUnits.kt
@@ -21,6 +21,11 @@ class Power(suffix: String, ratio: BigDecimal = BigDecimal.ONE) : Units(suffix, 
         val watt = Power("W")
         val kiloWatt = Power("kW", 1_000.toBigDecimal())
         val megaWatt = Power("MW", 1_000_000.0.toBigDecimal())
+    }
+}
+
+class ReactivePower(suffix: String, ratio: BigDecimal = BigDecimal.ONE) : Units(suffix, ratio) {
+    companion object {
         val voltAmpereReactive = Power("var")
         val kiloVoltAmpereReactive = Power("kvar", 1_000.toBigDecimal())
         val megaVoltAmpereReactive = Power("Mvar", 1_000_000.0.toBigDecimal())

--- a/measure/src/main/kotlin/com/alliander/open/measure/extension/ReactivePower.kt
+++ b/measure/src/main/kotlin/com/alliander/open/measure/extension/ReactivePower.kt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024-2025 Alliander N.V.
+//
+// SPDX-License-Identifier: MPL-2.0
+
 package com.alliander.open.measure.extension
 
 import com.alliander.open.measure.Measure

--- a/measure/src/main/kotlin/com/alliander/open/measure/extension/ReactivePower.kt
+++ b/measure/src/main/kotlin/com/alliander/open/measure/extension/ReactivePower.kt
@@ -1,0 +1,13 @@
+package com.alliander.open.measure.extension
+
+import com.alliander.open.measure.Measure
+import com.alliander.open.measure.ReactivePower
+import com.alliander.open.measure.times
+
+val ZERO_REACTIVE_POWER = 0 * ReactivePower.voltAmpereReactive
+
+@JvmName("sumReactivePowers")
+fun List<Measure<ReactivePower>>.sum(): Measure<ReactivePower> =
+    this.fold(ZERO_REACTIVE_POWER) { value, acc ->
+        value + acc
+    }

--- a/measure/src/test/kotlin/com/alliander/open/measure/extension/PowerTest.kt
+++ b/measure/src/test/kotlin/com/alliander/open/measure/extension/PowerTest.kt
@@ -11,12 +11,12 @@ import com.alliander.open.measure.Energy.Companion.megaJoule
 import com.alliander.open.measure.Energy.Companion.megaWattHour
 import com.alliander.open.measure.Measure
 import com.alliander.open.measure.Power
-import com.alliander.open.measure.Power.Companion.kiloVoltAmpereReactive
 import com.alliander.open.measure.Power.Companion.kiloWatt
-import com.alliander.open.measure.Power.Companion.megaVoltAmpereReactive
 import com.alliander.open.measure.Power.Companion.megaWatt
-import com.alliander.open.measure.Power.Companion.voltAmpereReactive
 import com.alliander.open.measure.Power.Companion.watt
+import com.alliander.open.measure.ReactivePower.Companion.kiloVoltAmpereReactive
+import com.alliander.open.measure.ReactivePower.Companion.megaVoltAmpereReactive
+import com.alliander.open.measure.ReactivePower.Companion.voltAmpereReactive
 import com.alliander.open.measure.times
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe

--- a/measure/src/test/kotlin/com/alliander/open/measure/extension/PowerTest.kt
+++ b/measure/src/test/kotlin/com/alliander/open/measure/extension/PowerTest.kt
@@ -4,20 +4,17 @@
 
 package com.alliander.open.measure.extension
 
-import com.alliander.open.measure.Energy
+import com.alliander.open.measure.*
 import com.alliander.open.measure.Energy.Companion.joule
 import com.alliander.open.measure.Energy.Companion.kiloJoule
 import com.alliander.open.measure.Energy.Companion.megaJoule
 import com.alliander.open.measure.Energy.Companion.megaWattHour
-import com.alliander.open.measure.Measure
-import com.alliander.open.measure.Power
 import com.alliander.open.measure.Power.Companion.kiloWatt
 import com.alliander.open.measure.Power.Companion.megaWatt
 import com.alliander.open.measure.Power.Companion.watt
 import com.alliander.open.measure.ReactivePower.Companion.kiloVoltAmpereReactive
 import com.alliander.open.measure.ReactivePower.Companion.megaVoltAmpereReactive
 import com.alliander.open.measure.ReactivePower.Companion.voltAmpereReactive
-import com.alliander.open.measure.times
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
@@ -36,6 +33,14 @@ class PowerTest : StringSpec({
         val result = list.sum()
 
         val expectedResult = 3001007 * watt
+        result shouldBe expectedResult
+    }
+
+    "reactivePowerSum returns 0 voltAmpere when given an empty list" {
+        val list = emptyList<Measure<ReactivePower>>()
+        val result = list.sum()
+
+        val expectedResult = 0 * voltAmpereReactive
         result shouldBe expectedResult
     }
 

--- a/measure/src/test/kotlin/com/alliander/open/measure/extension/PowerTest.kt
+++ b/measure/src/test/kotlin/com/alliander/open/measure/extension/PowerTest.kt
@@ -11,8 +11,11 @@ import com.alliander.open.measure.Energy.Companion.megaJoule
 import com.alliander.open.measure.Energy.Companion.megaWattHour
 import com.alliander.open.measure.Measure
 import com.alliander.open.measure.Power
+import com.alliander.open.measure.Power.Companion.kiloVoltAmpereReactive
 import com.alliander.open.measure.Power.Companion.kiloWatt
+import com.alliander.open.measure.Power.Companion.megaVoltAmpereReactive
 import com.alliander.open.measure.Power.Companion.megaWatt
+import com.alliander.open.measure.Power.Companion.voltAmpereReactive
 import com.alliander.open.measure.Power.Companion.watt
 import com.alliander.open.measure.times
 import io.kotest.core.spec.style.StringSpec
@@ -33,6 +36,15 @@ class PowerTest : StringSpec({
         val result = list.sum()
 
         val expectedResult = 3001007 * watt
+        result shouldBe expectedResult
+    }
+
+    "powerSum returns correct voltAmpere when given a list of measures of power" {
+        val list = listOf(3 * voltAmpereReactive, 3 * kiloVoltAmpereReactive, 1 * voltAmpereReactive,
+            3 * megaVoltAmpereReactive, 4 * voltAmpereReactive)
+        val result = list.sum()
+
+        val expectedResult = 3003008 * voltAmpereReactive
         result shouldBe expectedResult
     }
 


### PR DESCRIPTION
MRT-2464: add volt-ampere reactive - checked with the Phase to Phase handbook

Signed-off-by: Shelphi <shirley.houter@alliander.com>